### PR TITLE
fix(untracked): prevent ignoring untracked files

### DIFF
--- a/.post-merge.sh
+++ b/.post-merge.sh
@@ -3,6 +3,9 @@
 # Concat all files ending with .gitignore into a single temporary file
 find . -type f -name "*.gitignore" -exec sh -c 'cat {} >> ".gitignore_packlink.new"' \;
 
+# Remove entry that ignores untracked files
+sed -i -e '/^\/\*$/d' ./.gitignore_packlink.new
+
 # Move the temporary file into the final location
 mv ./.gitignore_packlink.new $HOME/.gitignore_packlink
 


### PR DESCRIPTION
Differences between the original gitignore file and the newly generated one:
```
$ diff .gitignore_packlink .gitignore_packlink_original
5604a5605
> /*
```
The entry provoking all untracked files to be ignored is removed. That line was present as part of the JENKINS gitignore file.