### PR TITLE
P1-394 git ignores the config folder

### DIFF
--- a/.post-merge.sh
+++ b/.post-merge.sh
@@ -15,6 +15,9 @@ sed -i -e '/^\*\.sql$/d' ./.gitignore_packlink.new
 # Remove entry that ignores untracked certificates
 sed -i -e '/^\*\.crt$/d' ./.gitignore_packlink.new
 
+# Remove entry that ignores the \config folder
+sed -i -e '/^\/config\/\*$/d' ./.gitignore_packlink.new
+
 # Move the temporary file into the final location
 mv ./.gitignore_packlink.new $HOME/.gitignore_packlink
 


### PR DESCRIPTION
- Remove entry that ignores the content of the config folder

The config folder is used by some microservices, like tracking-service or data-integration-kettle.