### PR TITLE
Add new '.bsp' folder that may be created in SBT projects

### DIFF
--- a/Global/SBT.gitignore
+++ b/Global/SBT.gitignore
@@ -10,3 +10,4 @@ project/plugins/project/
 .history
 .cache
 .lib/
+.bsp/


### PR DESCRIPTION
**Reasons for making this change:**

[SBT 1.4.x](https://github.com/sbt/sbt/releases/tag/v1.4.0) introduces support for "Build Server Protocol", which in terms of project structure may lead to the creation of a `.bsp` folder in the project path which should not be committed to Git.

"When sbt 1.4.0 starts, it will create a file named .bsp/sbt.json containing a machine-readable instruction on how to run sbt -bsp, which is a command line program that uses standard input and output to communicate to sbt server using build server protocol."

**Links to documentation supporting these rule changes:**

https://github.com/sbt/sbt/releases/tag/v1.4.0
