### PR TITLE
P1-938 : api folder ignored by global gitignore

### DIFF
--- a/.post-merge.sh
+++ b/.post-merge.sh
@@ -24,6 +24,9 @@ sed -i -e '/^\*\.xml$/d' ./.gitignore_packlink.new
 # Remove entry that ignores the test/ folder
 sed -i -e '/^test\/$/d' ./.gitignore_packlink.new
 
+# Remove entry that ignores the api/ folder
+sed -i -e '/^api$/d' ./.gitignore_packlink.new
+
 # Remove entry that ignores the _snapshots_/ folder
 sed -i -e '/^_snapshots_\/$/d' ./.gitignore_packlink.new
 


### PR DESCRIPTION
**Reasons for making this change:**

https://github.com/packlink-dev/api-proxy/tree/master/src/gateway/api folder is getting ignored by this rule: https://github.com/github/gitignore/blob/218a941be92679ce67d0484547e3e142b2f5f6f0/Qooxdoo.gitignore#L4

**Links to documentation supporting these rule changes:**

https://packlink.atlassian.net/browse/P1-938

